### PR TITLE
[ISSUE 9] Reused container ID. Added default no change state.

### DIFF
--- a/app/src/main/java/com/mitteloupe/whoami/ui/main/AppNavHost.kt
+++ b/app/src/main/java/com/mitteloupe/whoami/ui/main/AppNavHost.kt
@@ -29,6 +29,7 @@ fun AppNavHost(
     navController: NavHostController = rememberNavController(),
     startDestination: String = "home"
 ) {
+    val containerId by rememberSaveable { mutableStateOf(View.generateViewId()) }
     NavHost(
         modifier = modifier,
         navController = navController,
@@ -48,6 +49,7 @@ fun AppNavHost(
         }
         composable("history") {
             FragmentContainer(
+                containerId = containerId,
                 modifier = Modifier.fillMaxSize(),
                 fragmentManager = supportFragmentManager,
                 commit = { containerId -> replace(containerId, HistoryFragment.newInstance()) },
@@ -63,12 +65,12 @@ fun AppNavHost(
 
 @Composable
 fun FragmentContainer(
+    containerId: Int,
     modifier: Modifier = Modifier,
     fragmentManager: FragmentManager,
     commit: FragmentTransaction.(containerId: Int) -> Unit,
     onFragmentViewCreated: (containerId: Int) -> Unit
 ) {
-    val containerId by rememberSaveable { mutableStateOf(View.generateViewId()) }
     var initialized by rememberSaveable { mutableStateOf(false) }
     AndroidView(
         modifier = modifier,
@@ -77,12 +79,12 @@ fun FragmentContainer(
                 .apply { id = containerId }
         },
         update = { view ->
-            if (!initialized) {
-                fragmentManager.commit { commit(view.id) }
-                initialized = true
-            } else {
+            if (initialized) {
                 fragmentManager.onContainerAvailable(view)
                 onFragmentViewCreated(view.id)
+            } else {
+                fragmentManager.commit { commit(view.id) }
+                initialized = true
             }
         }
     )

--- a/history/presentation/src/main/java/com/mitteloupe/whoami/history/presentation/model/HistoryViewState.kt
+++ b/history/presentation/src/main/java/com/mitteloupe/whoami/history/presentation/model/HistoryViewState.kt
@@ -1,6 +1,8 @@
 package com.mitteloupe.whoami.history.presentation.model
 
 sealed interface HistoryViewState {
+    object NoChange : HistoryViewState
+
     object Loading : HistoryViewState
 
     data class HistoryRecords(

--- a/history/presentation/src/main/java/com/mitteloupe/whoami/history/presentation/viewmodel/HistoryViewModel.kt
+++ b/history/presentation/src/main/java/com/mitteloupe/whoami/history/presentation/viewmodel/HistoryViewModel.kt
@@ -8,13 +8,14 @@ import com.mitteloupe.whoami.history.presentation.mapper.SavedIpAddressRecordToP
 import com.mitteloupe.whoami.history.presentation.model.HistoryViewState
 import com.mitteloupe.whoami.history.presentation.model.HistoryViewState.HistoryRecords
 import com.mitteloupe.whoami.history.presentation.model.HistoryViewState.Loading
+import com.mitteloupe.whoami.history.presentation.model.HistoryViewState.NoChange
 
 class HistoryViewModel(
     private val getHistoryUseCase: GetHistoryUseCase,
     private val savedIpAddressRecordToPresentationMapper: SavedIpAddressRecordToPresentationMapper,
     useCaseExecutor: UseCaseExecutor
 ) : BaseViewModel<HistoryViewState, Any>(useCaseExecutor) {
-    override val initialViewState = Loading
+    override val initialViewState = NoChange
 
     fun onEnter() {
         updateViewState(Loading)

--- a/history/presentation/src/test/java/com/mitteloupe/whoami/history/presentation/viewmodel/HistoryViewModelTest.kt
+++ b/history/presentation/src/test/java/com/mitteloupe/whoami/history/presentation/viewmodel/HistoryViewModelTest.kt
@@ -7,7 +7,7 @@ import com.mitteloupe.whoami.history.domain.usecase.GetHistoryUseCase
 import com.mitteloupe.whoami.history.presentation.mapper.SavedIpAddressRecordToPresentationMapper
 import com.mitteloupe.whoami.history.presentation.model.HistoryViewState
 import com.mitteloupe.whoami.history.presentation.model.HistoryViewState.HistoryRecords
-import com.mitteloupe.whoami.history.presentation.model.HistoryViewState.Loading
+import com.mitteloupe.whoami.history.presentation.model.HistoryViewState.NoChange
 import com.mitteloupe.whoami.history.presentation.model.SavedIpAddressRecordPresentationModel
 import kotlinx.coroutines.runBlocking
 import org.hamcrest.CoreMatchers.instanceOf
@@ -23,7 +23,7 @@ import org.mockito.kotlin.given
 
 @RunWith(MockitoJUnitRunner::class)
 class HistoryViewModelTest : BaseViewModelTest<HistoryViewState, Any, HistoryViewModel>() {
-    override val expectedInitialState: HistoryViewState = Loading
+    override val expectedInitialState: HistoryViewState = NoChange
 
     @Mock
     private lateinit var getHistoryUseCase: GetHistoryUseCase

--- a/history/ui/src/main/java/com/mitteloupe/whoami/history/ui/binder/HistoryViewStateBinder.kt
+++ b/history/ui/src/main/java/com/mitteloupe/whoami/history/ui/binder/HistoryViewStateBinder.kt
@@ -29,19 +29,18 @@ class HistoryViewStateBinder(
             @Suppress("DEPRECATION", "UNCHECKED_CAST")
             getParcelableArray(HISTORY_RECORDS_BUNDLE_KEY) as Array<HistoryRecordUiModel>?
         }
-        viewsProvider.setUpAdapterAndBindItems(savedHistoryItems?.toList().orEmpty())
+
+        val historyItems = savedHistoryItems?.toList().orEmpty()
+        viewsProvider.renderHistoryRecords(historyItems)
     }
 
     override fun HistoryViewsProvider.bindState(viewState: HistoryViewState) {
         when (viewState) {
+            HistoryViewState.NoChange -> Unit
+
             is HistoryViewState.HistoryRecords -> {
-                noRecordsView.isVisible = viewState.historyRecords.isEmpty()
-                recordsListView.isVisible = viewState.historyRecords.isNotEmpty()
                 val historyItems = viewState.historyRecords.map(historyRecordToUiMapper::toUi)
-                    .sortedByDescending { historyRecord ->
-                        historyRecord.savedAtTimestampMilliseconds
-                    }
-                setUpAdapterAndBindItems(historyItems)
+                renderHistoryRecords(historyItems)
             }
 
             HistoryViewState.Loading -> {
@@ -49,6 +48,18 @@ class HistoryViewStateBinder(
                 recordsListView.isVisible = false
             }
         }
+    }
+
+    private fun HistoryViewsProvider.renderHistoryRecords(
+        historyItems: List<HistoryRecordUiModel>
+    ) {
+        noRecordsView.isVisible = historyItems.isEmpty()
+        recordsListView.isVisible = historyItems.isNotEmpty()
+        setUpAdapterAndBindItems(
+            historyItems.sortedByDescending { historyRecord ->
+                historyRecord.savedAtTimestampMilliseconds
+            }
+        )
     }
 
     private fun HistoryViewsProvider.setUpAdapterAndBindItems(


### PR DESCRIPTION
Expanded the scope of containerId so that it can be reused to prevent fragment memory leaks.
Introduced a no change state default to prevent the history screen from changing to a loading state by default when no loading will occur.