### PR TITLE
General update.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 android {
     namespace = "com.mitteloupe.whoami"
-    compileSdk = 33
+    compileSdk = 34
 
     buildFeatures {
         buildConfig = true
@@ -18,7 +18,7 @@ android {
     defaultConfig {
         applicationId = "com.mitteloupe.whoami"
         minSdk = 22
-        targetSdk = 33
+        targetSdk = 34
         versionCode = 1
         versionName = "1.0"
 
@@ -119,6 +119,10 @@ dependencies {
     implementation(libs.compose.navigation)
 
     implementation(project(":analytics"))
+
+    testImplementation(libs.test.junit)
+    testImplementation(libs.test.hamcrest)
+    testImplementation(libs.test.konsist)
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/architecture/instrumentation-test/build.gradle.kts
+++ b/architecture/instrumentation-test/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "com.mitteloupe.whoami.test"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 22

--- a/architecture/ui/build.gradle.kts
+++ b/architecture/ui/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "com.mitteloupe.whoami.home.ui"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 22

--- a/datasource/implementation/build.gradle.kts
+++ b/datasource/implementation/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "com.mitteloupe.whoami.datasource"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 22

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,9 +7,9 @@ androidx-recyclerview = "1.3.1"
 androidx-espresso-core = "3.5.1"
 androidx-junit = "1.1.5"
 androidx-lifecycle-runtime-ktx = "2.6.1"
-androidx-navigation-fragment-ktx = "2.6.0"
+androidx-navigation-fragment-ktx = "2.7.0"
 compose-activity = "1.7.2"
-compose-navigation = "2.6.0"
+compose-navigation = "2.7.0"
 hilt = "2.47"
 moshi = "1.14.0"
 retrofit = "2.9.0"
@@ -21,6 +21,7 @@ test-mockk = "1.13.5"
 test-mockito = "5.4.0"
 test-mockito-kotlin = "5.0.0"
 test-mockito-android = "2.28.3"
+test-konsist = "0.10.0"
 test-androidx-rules = "1.5.0"
 uiautomator = "2.2.0"
 okhttp3 = "4.11.0"
@@ -55,6 +56,7 @@ test-mockk = { module = "io.mockk:mockk", version.ref = "test-mockk" }
 test-mockito = { module = "org.mockito:mockito-core", version.ref = "test-mockito" }
 test-mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "test-mockito-kotlin" }
 test-mockito-android = { module = "com.linkedin.dexmaker:dexmaker-mockito-inline", version.ref = "test-mockito-android" }
+test-konsist = { module = "com.lemonappdev:konsist", version.ref = "test-konsist" }
 test-android-hilt = { module = "com.google.dagger:hilt-android-testing", version.ref = "hilt" }
 test-android-uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "uiautomator" }
 test-android-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp3" }

--- a/history/ui/build.gradle.kts
+++ b/history/ui/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 android {
     namespace = "com.mitteloupe.whoami.history.ui"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 22

--- a/home/ui/build.gradle.kts
+++ b/home/ui/build.gradle.kts
@@ -67,13 +67,13 @@ dependencies {
 
     implementation(project(":analytics"))
 
-    implementation(platform("androidx.compose:compose-bom:2023.06.01"))
+    implementation(platform("androidx.compose:compose-bom:2023.08.00"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
 
-    debugImplementation("androidx.compose.ui:ui-tooling:1.4.3")
+    debugImplementation("androidx.compose.ui:ui-tooling")
 
     testImplementation(libs.test.junit)
     testImplementation(libs.test.hamcrest)

--- a/home/ui/build.gradle.kts
+++ b/home/ui/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "com.mitteloupe.whoami.home.ui"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 22

--- a/widget/build.gradle.kts
+++ b/widget/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "com.mitteloupe.whoami.widget"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 22


### PR DESCRIPTION
Targeted SDK 34.
Bumped Compose to 023.08.00 bill of materials.
Bumped navigation-fragment-ktx to 2.7.0.
Added Konsist. This will be used later to help maintaining architectural integrity.
