### PR TITLE
Upgraded navigation libraries to 2.7.5. Combined versions.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,10 +5,9 @@ androidx-core-ktx = "1.12.0"
 androidx-fragment-ktx = "1.6.2"
 androidx-recyclerview = "1.3.2"
 androidx-lifecycle-runtime-ktx = "2.6.2"
-androidx-navigation-fragment-ktx = "2.7.4"
+android-navigation = "2.7.5"
 compose-bom = "2023.10.01"
 compose-activity = "1.8.0"
-compose-navigation = "2.7.4"
 hilt = "2.48.1"
 moshi = "1.15.0"
 retrofit = "2.9.0"
@@ -44,7 +43,7 @@ compose-ui-graphics = { module = "androidx.compose.ui:ui-graphics" }
 compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 compose-material3 = { module = "androidx.compose.material3:material3" }
 compose-activity = { module = "androidx.activity:activity-compose", version.ref = "compose-activity" }
-compose-navigation = { module = "androidx.navigation:navigation-compose", version.ref = "compose-navigation" }
+compose-navigation = { module = "androidx.navigation:navigation-compose", version.ref = "android-navigation" }
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
 moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }
@@ -75,7 +74,7 @@ test-androidx-rules = { module = "androidx.test:rules", version.ref = "test-andr
 test-compose-ui-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
 debug-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 debug-compose-ui-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
-androidx-navigation-fragment-ktx = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "androidx-navigation-fragment-ktx" }
+androidx-navigation-fragment-ktx = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "android-navigation" }
 plugin-oss-licenses = { module = "com.google.android.gms:oss-licenses-plugin", version.ref = "plugin-oss-licenses" }
 
 [bundles]


### PR DESCRIPTION
This PR replaces and combines:

https://github.com/EranBoudjnah/CleanArchitectureForAndroid/pull/79
https://github.com/EranBoudjnah/CleanArchitectureForAndroid/pull/80
