### PR TITLE
Downgraded CI to macos-13 to unbreak emulator.

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -38,7 +38,7 @@ jobs:
   unit-tests:
     needs: setup
 
-    runs-on: macos-latest
+    runs-on: macos-13
 
     steps:
       - name: Checkout
@@ -65,7 +65,7 @@ jobs:
   connected-tests:
     needs: setup
 
-    runs-on: macos-latest
+    runs-on: macos-13
 
     steps:
       - name: Checkout

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   setup:
-    runs-on: macos-latest
+    runs-on: macos-13
 
     steps:
       - name: Checkout

--- a/.github/workflows/ktlint.yml
+++ b/.github/workflows/ktlint.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   ktlint:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - name: Get changed files
         id: changes


### PR DESCRIPTION
github upgraded the MacOS version. This breaks the emulator extension and CI tests fail. Downgrading to MacOS-13 is a workaround until a better solution can be found.

See here: https://github.com/ReactiveCircus/android-emulator-runner/issues/392#issuecomment-2106167725