### PR TITLE
Minor tidying up.

### DIFF
--- a/architecture/instrumentation-test/build.gradle.kts
+++ b/architecture/instrumentation-test/build.gradle.kts
@@ -54,11 +54,6 @@ detekt {
 }
 
 dependencies {
-    implementation(projects.architecture.presentation)
-
-    implementation(projects.coroutine)
-    implementation(projects.widget)
-
     implementation(libs.material)
 
     implementation(platform(libs.compose.bom))

--- a/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/matcher/WithDrawableIdMatcher.kt
+++ b/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/matcher/WithDrawableIdMatcher.kt
@@ -10,11 +10,11 @@ import android.graphics.drawable.Drawable
 import android.graphics.drawable.StateListDrawable
 import android.os.Build
 import android.util.Log
+import android.view.MenuItem
 import android.view.View
 import android.widget.ImageView
 import androidx.annotation.DrawableRes
 import androidx.appcompat.view.menu.ActionMenuItemView
-import androidx.appcompat.view.menu.MenuItemImpl
 import androidx.core.content.res.ResourcesCompat
 import androidx.test.platform.app.InstrumentationRegistry
 import kotlin.reflect.KClass
@@ -103,7 +103,7 @@ class WithDrawableIdMatcher(@param:DrawableRes private val expectedId: Int) :
         get() {
             val itemData = this::class.members.first {
                 it.name == "getItemData"
-            }.call() as MenuItemImpl
+            }.call() as MenuItem
 
             return itemData::class.members.first {
                 it.name == "getIcon"

--- a/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/test/BaseTest.kt
+++ b/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/test/BaseTest.kt
@@ -40,9 +40,6 @@ import org.junit.rules.RuleChain
 import org.junit.rules.TestRule
 
 abstract class BaseTest {
-    internal val targetContext
-        get() = getInstrumentation().targetContext
-
     private val hiltAndroidRule by lazy { HiltAndroidRule(this) }
 
     @Inject

--- a/history/presentation/src/test/java/com/mitteloupe/whoami/history/presentation/viewmodel/HistoryViewModelTest.kt
+++ b/history/presentation/src/test/java/com/mitteloupe/whoami/history/presentation/viewmodel/HistoryViewModelTest.kt
@@ -91,7 +91,7 @@ class HistoryViewModelTest :
                 (actualValue as HistoryRecords).highlightedIpAddress
             )
             assertThat(
-                (actualValue as HistoryRecords).historyRecords,
+                actualValue.historyRecords,
                 hasSize(expectedSavedRecords.size)
             )
             expectedSavedRecords.forEach { expectedRecord ->
@@ -107,7 +107,7 @@ class HistoryViewModelTest :
         val givenIpAddressRecord2 = domainHistoryRecord("1.1.1.1")
         val givenHistory = setOf(givenIpAddressRecord1, givenIpAddressRecord2)
         givenSuccessfulUseCaseExecution(getHistoryUseCase, givenHistory)
-        val highlightedIpAddress: String? = "0.0.0.0"
+        val highlightedIpAddress = "0.0.0.0"
 
         // When
         classUnderTest.onEnter(highlightedIpAddress)

--- a/history/ui/src/main/res/layout/item_history.xml
+++ b/history/ui/src/main/res/layout/item_history.xml
@@ -25,7 +25,6 @@
                 android:layout_width="40dp"
                 android:layout_height="40dp"
                 android:layout_marginEnd="16dp"
-                android:layout_marginRight="16dp"
                 android:alpha="0.5"
                 android:contentDescription="@string/history_record_saved_record_icon_hint"
                 app:layout_constraintBottom_toBottomOf="parent"

--- a/home/domain/src/test/java/com/mitteloupe/whoami/home/domain/usecase/GetConnectionDetailsUseCaseTest.kt
+++ b/home/domain/src/test/java/com/mitteloupe/whoami/home/domain/usecase/GetConnectionDetailsUseCaseTest.kt
@@ -4,7 +4,7 @@ import com.mitteloupe.whoami.coroutine.CoroutineContextProvider
 import com.mitteloupe.whoami.home.domain.model.ConnectionDetailsDomainModel
 import com.mitteloupe.whoami.home.domain.repository.GetConnectionDetailsRepository
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.flow.lastOrNull
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -39,9 +39,9 @@ class GetConnectionDetailsUseCaseTest {
                 .willReturn(flowOf(expectedConnectionDetails))
 
             // When
-            val actualValue = classUnderTest.executeInBackground(Unit).toList()
+            val actualValue = classUnderTest.executeInBackground(Unit).lastOrNull()
 
             // Then
-            assertEquals(listOf(expectedConnectionDetails), actualValue)
+            assertEquals(expectedConnectionDetails, actualValue)
         }
 }

--- a/widget/build.gradle.kts
+++ b/widget/build.gradle.kts
@@ -13,7 +13,6 @@ android {
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()
 
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
             useSupportLibrary = true
         }
@@ -58,8 +57,4 @@ dependencies {
     implementation(libs.compose.ui.graphics)
     implementation(libs.compose.ui.tooling.preview)
     implementation(libs.compose.material3)
-
-    testImplementation(libs.test.junit)
-    androidTestImplementation(libs.test.androidx.junit)
-    androidTestImplementation(libs.test.androidx.espresso.core)
 }


### PR DESCRIPTION
Removed unused dependencies.
Used publically available `MenuItem` instead of the hidden `MenuItemImpl`.
Removed unused `targetContext`.
Removed casting and explicit type which aren't needed anymore.
Stabilized test.