### PR TITLE
Extracted coroutines from UseCase.

### DIFF
--- a/architecture/domain/src/main/java/com/mitteloupe/whoami/architecture/domain/UseCaseExecutor.kt
+++ b/architecture/domain/src/main/java/com/mitteloupe/whoami/architecture/domain/UseCaseExecutor.kt
@@ -3,14 +3,8 @@ package com.mitteloupe.whoami.architecture.domain
 import com.mitteloupe.whoami.architecture.domain.exception.DomainException
 import com.mitteloupe.whoami.architecture.domain.exception.UnknownDomainException
 import com.mitteloupe.whoami.architecture.domain.usecase.UseCase
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 
-class UseCaseExecutor(
-    private val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Main)
-) {
+class UseCaseExecutor {
     fun <OUTPUT> execute(
         useCase: UseCase<Unit, OUTPUT>,
         onResult: (OUTPUT) -> Unit = {},
@@ -23,16 +17,12 @@ class UseCaseExecutor(
         onResult: (OUTPUT) -> Unit = {},
         onException: (DomainException) -> Unit = {}
     ) {
-        coroutineScope.launch {
-            try {
-                useCase.execute(value, onResult)
-            } catch (_: CancellationException) {
-            } catch (@Suppress("TooGenericExceptionCaught") throwable: Throwable) {
-                onException(
-                    (throwable as? DomainException)
-                        ?: UnknownDomainException(throwable)
-                )
-            }
+        try {
+            useCase.execute(value, onResult)
+        } catch (@Suppress("TooGenericExceptionCaught") throwable: Throwable) {
+            val domainException =
+                ((throwable as? DomainException) ?: UnknownDomainException(throwable))
+            onException(domainException)
         }
     }
 }

--- a/architecture/domain/src/main/java/com/mitteloupe/whoami/architecture/domain/usecase/BackgroundExecutingUseCase.kt
+++ b/architecture/domain/src/main/java/com/mitteloupe/whoami/architecture/domain/usecase/BackgroundExecutingUseCase.kt
@@ -1,16 +1,26 @@
 package com.mitteloupe.whoami.architecture.domain.usecase
 
 import com.mitteloupe.whoami.coroutine.CoroutineContextProvider
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 abstract class BackgroundExecutingUseCase<REQUEST, RESULT>(
-    private val coroutineContextProvider: CoroutineContextProvider
+    private val coroutineContextProvider: CoroutineContextProvider,
+    private val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Main)
 ) : UseCase<REQUEST, RESULT> {
-    final override suspend fun execute(input: REQUEST, onResult: (RESULT) -> Unit) {
-        val result = withContext(coroutineContextProvider.io) {
-            executeInBackground(input)
+    final override fun execute(input: REQUEST, onResult: (RESULT) -> Unit) {
+        try {
+            coroutineScope.launch {
+                val result = withContext(coroutineContextProvider.io) {
+                    executeInBackground(input)
+                }
+                onResult(result)
+            }
+        } catch (_: CancellationException) {
         }
-        onResult(result)
     }
 
     abstract fun executeInBackground(request: REQUEST): RESULT

--- a/architecture/domain/src/main/java/com/mitteloupe/whoami/architecture/domain/usecase/ContinuousExecutingUseCase.kt
+++ b/architecture/domain/src/main/java/com/mitteloupe/whoami/architecture/domain/usecase/ContinuousExecutingUseCase.kt
@@ -1,19 +1,29 @@
 package com.mitteloupe.whoami.architecture.domain.usecase
 
 import com.mitteloupe.whoami.coroutine.CoroutineContextProvider
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 abstract class ContinuousExecutingUseCase<REQUEST, RESULT>(
-    private val coroutineContextProvider: CoroutineContextProvider
+    private val coroutineContextProvider: CoroutineContextProvider,
+    private val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Main)
 ) : UseCase<REQUEST, RESULT> {
-    final override suspend fun execute(input: REQUEST, onResult: (RESULT) -> Unit) {
-        withContext(coroutineContextProvider.io) {
-            executeInBackground(input).collect { result ->
-                withContext(coroutineContextProvider.main) {
-                    onResult(result)
+    final override fun execute(input: REQUEST, onResult: (RESULT) -> Unit) {
+        try {
+            coroutineScope.launch {
+                withContext(coroutineContextProvider.io) {
+                    executeInBackground(input).collect { result ->
+                        withContext(coroutineContextProvider.main) {
+                            onResult(result)
+                        }
+                    }
                 }
             }
+        } catch (_: CancellationException) {
         }
     }
 

--- a/architecture/domain/src/main/java/com/mitteloupe/whoami/architecture/domain/usecase/UseCase.kt
+++ b/architecture/domain/src/main/java/com/mitteloupe/whoami/architecture/domain/usecase/UseCase.kt
@@ -1,5 +1,5 @@
 package com.mitteloupe.whoami.architecture.domain.usecase
 
 interface UseCase<REQUEST, RESULT> {
-    suspend fun execute(input: REQUEST, onResult: (RESULT) -> Unit)
+    fun execute(input: REQUEST, onResult: (RESULT) -> Unit)
 }


### PR DESCRIPTION
This change makes the basic UseCase more "vanilla". It also simplifies the `UseCaseExecutor`.