### PR TITLE
Polished Presentation mapper naming.

### DIFF
--- a/app/src/main/java/com/mitteloupe/whoami/di/HomeModule.kt
+++ b/app/src/main/java/com/mitteloupe/whoami/di/HomeModule.kt
@@ -6,9 +6,9 @@ import com.mitteloupe.whoami.home.domain.repository.GetConnectionDetailsReposito
 import com.mitteloupe.whoami.home.domain.repository.SaveConnectionDetailsRepository
 import com.mitteloupe.whoami.home.domain.usecase.GetConnectionDetailsUseCase
 import com.mitteloupe.whoami.home.domain.usecase.SaveConnectionDetailsUseCase
+import com.mitteloupe.whoami.home.presentation.mapper.ConnectionDetailsPresentationMapper
 import com.mitteloupe.whoami.home.presentation.mapper.ConnectionDetailsToDomainMapper
-import com.mitteloupe.whoami.home.presentation.mapper.ConnectionStateToPresentationMapper
-import com.mitteloupe.whoami.home.presentation.mapper.ExceptionToPresentationMapper
+import com.mitteloupe.whoami.home.presentation.mapper.ExceptionPresentationMapper
 import com.mitteloupe.whoami.home.presentation.viewmodel.HomeViewModel
 import dagger.Module
 import dagger.Provides
@@ -26,8 +26,8 @@ object HomeModule {
 
     @Provides
     fun providesConnectionStateToPresentationMapper(
-        exceptionToPresentationMapper: ExceptionToPresentationMapper
-    ) = ConnectionStateToPresentationMapper(exceptionToPresentationMapper)
+        exceptionPresentationMapper: ExceptionPresentationMapper
+    ) = ConnectionDetailsPresentationMapper(exceptionPresentationMapper)
 
     @Provides
     fun providesSaveConnectionDetailsUseCase(
@@ -39,22 +39,22 @@ object HomeModule {
     fun providesConnectionDetailsToDomainMapper() = ConnectionDetailsToDomainMapper()
 
     @Provides
-    fun providesExceptionToPresentationMapper() = ExceptionToPresentationMapper()
+    fun providesExceptionToPresentationMapper() = ExceptionPresentationMapper()
 
     @Provides
     fun providesHomeViewModel(
         getConnectionDetailsUseCase: GetConnectionDetailsUseCase,
-        connectionStateToPresentationMapper: ConnectionStateToPresentationMapper,
+        connectionDetailsPresentationMapper: ConnectionDetailsPresentationMapper,
         saveConnectionDetailsUseCase: SaveConnectionDetailsUseCase,
         connectionDetailsToDomainMapper: ConnectionDetailsToDomainMapper,
-        exceptionToPresentationMapper: ExceptionToPresentationMapper,
+        exceptionPresentationMapper: ExceptionPresentationMapper,
         useCaseExecutor: UseCaseExecutor
     ) = HomeViewModel(
         getConnectionDetailsUseCase,
-        connectionStateToPresentationMapper,
+        connectionDetailsPresentationMapper,
         saveConnectionDetailsUseCase,
         connectionDetailsToDomainMapper,
-        exceptionToPresentationMapper,
+        exceptionPresentationMapper,
         useCaseExecutor
     )
 }

--- a/home/presentation/src/main/java/com/mitteloupe/whoami/home/presentation/mapper/ConnectionDetailsPresentationMapper.kt
+++ b/home/presentation/src/main/java/com/mitteloupe/whoami/home/presentation/mapper/ConnectionDetailsPresentationMapper.kt
@@ -7,8 +7,8 @@ import com.mitteloupe.whoami.home.domain.model.ConnectionDetailsDomainModel.Erro
 import com.mitteloupe.whoami.home.domain.model.ConnectionDetailsDomainModel.Unset
 import com.mitteloupe.whoami.home.presentation.model.HomeViewState
 
-class ConnectionStateToPresentationMapper(
-    private val exceptionToPresentationMapper: ExceptionToPresentationMapper
+class ConnectionDetailsPresentationMapper(
+    private val exceptionPresentationMapper: ExceptionPresentationMapper
 ) {
     fun toPresentation(connectionDetails: ConnectionDetailsDomainModel) = when (connectionDetails) {
         is Connected -> HomeViewState.Connected(
@@ -26,7 +26,7 @@ class ConnectionStateToPresentationMapper(
         Unset -> HomeViewState.Loading
         is Error -> {
             HomeViewState.Error(
-                exceptionToPresentationMapper.toPresentation(connectionDetails.exception)
+                exceptionPresentationMapper.toPresentation(connectionDetails.exception)
             )
         }
     }

--- a/home/presentation/src/main/java/com/mitteloupe/whoami/home/presentation/mapper/ExceptionPresentationMapper.kt
+++ b/home/presentation/src/main/java/com/mitteloupe/whoami/home/presentation/mapper/ExceptionPresentationMapper.kt
@@ -9,7 +9,7 @@ import com.mitteloupe.whoami.home.presentation.model.ErrorPresentationModel.NoIp
 import com.mitteloupe.whoami.home.presentation.model.ErrorPresentationModel.RequestTimeout
 import com.mitteloupe.whoami.home.presentation.model.ErrorPresentationModel.Unknown
 
-class ExceptionToPresentationMapper {
+class ExceptionPresentationMapper {
     fun toPresentation(exception: DomainException) = when (exception) {
         is ReadFailedDomainException -> RequestTimeout
         is NoIpAddressDomainException -> NoIpAddress

--- a/home/presentation/src/main/java/com/mitteloupe/whoami/home/presentation/viewmodel/HomeViewModel.kt
+++ b/home/presentation/src/main/java/com/mitteloupe/whoami/home/presentation/viewmodel/HomeViewModel.kt
@@ -4,9 +4,9 @@ import com.mitteloupe.whoami.architecture.domain.UseCaseExecutor
 import com.mitteloupe.whoami.architecture.presentation.viewmodel.BaseViewModel
 import com.mitteloupe.whoami.home.domain.usecase.GetConnectionDetailsUseCase
 import com.mitteloupe.whoami.home.domain.usecase.SaveConnectionDetailsUseCase
+import com.mitteloupe.whoami.home.presentation.mapper.ConnectionDetailsPresentationMapper
 import com.mitteloupe.whoami.home.presentation.mapper.ConnectionDetailsToDomainMapper
-import com.mitteloupe.whoami.home.presentation.mapper.ConnectionStateToPresentationMapper
-import com.mitteloupe.whoami.home.presentation.mapper.ExceptionToPresentationMapper
+import com.mitteloupe.whoami.home.presentation.mapper.ExceptionPresentationMapper
 import com.mitteloupe.whoami.home.presentation.model.HomePresentationNotification
 import com.mitteloupe.whoami.home.presentation.model.HomePresentationNotification.ConnectionSaved
 import com.mitteloupe.whoami.home.presentation.model.HomeViewState
@@ -18,10 +18,10 @@ import com.mitteloupe.whoami.home.presentation.navigation.HomePresentationNaviga
 
 class HomeViewModel(
     private val getConnectionDetailsUseCase: GetConnectionDetailsUseCase,
-    private val connectionStateToPresentationMapper: ConnectionStateToPresentationMapper,
+    private val connectionDetailsPresentationMapper: ConnectionDetailsPresentationMapper,
     private val saveConnectionDetailsUseCase: SaveConnectionDetailsUseCase,
     private val connectionDetailsToDomainMapper: ConnectionDetailsToDomainMapper,
-    private val exceptionToPresentationMapper: ExceptionToPresentationMapper,
+    private val exceptionPresentationMapper: ExceptionPresentationMapper,
     useCaseExecutor: UseCaseExecutor
 ) : BaseViewModel<HomeViewState, HomePresentationNotification>(useCaseExecutor, Loading) {
     fun onEnter() {
@@ -29,11 +29,11 @@ class HomeViewModel(
         getConnectionDetailsUseCase(
             onResult = { result ->
                 updateViewState(
-                    connectionStateToPresentationMapper.toPresentation(result)
+                    connectionDetailsPresentationMapper.toPresentation(result)
                 )
             },
             onException = { exception ->
-                updateViewState(Error(exceptionToPresentationMapper.toPresentation(exception)))
+                updateViewState(Error(exceptionPresentationMapper.toPresentation(exception)))
             }
         )
     }
@@ -49,7 +49,7 @@ class HomeViewModel(
                 )
             },
             onException = { exception ->
-                updateViewState(Error(exceptionToPresentationMapper.toPresentation(exception)))
+                updateViewState(Error(exceptionPresentationMapper.toPresentation(exception)))
             }
         )
     }

--- a/home/presentation/src/test/java/com/mitteloupe/whoami/home/presentation/mapper/ConnectionDetailsToPresentationMapperTest.kt
+++ b/home/presentation/src/test/java/com/mitteloupe/whoami/home/presentation/mapper/ConnectionDetailsToPresentationMapperTest.kt
@@ -22,10 +22,10 @@ import org.mockito.junit.MockitoJUnit
 import org.mockito.kotlin.given
 
 @RunWith(Parameterized::class)
-class ConnectionStateToPresentationMapperTest(
+class ConnectionDetailsToPresentationMapperTest(
     private val givenConnectionDetails: ConnectionDetailsDomainModel,
     private val expectedViewState: HomeViewState,
-    private val stubMapper: ExceptionToPresentationMapper.() -> Unit
+    private val stubMapper: ExceptionPresentationMapper.() -> Unit
 ) {
     companion object {
         @JvmStatic
@@ -59,7 +59,7 @@ class ConnectionStateToPresentationMapperTest(
         private fun testCase(
             connectionDetails: ConnectionDetailsDomainModel,
             viewState: HomeViewState,
-            stubMapper: ExceptionToPresentationMapper.() -> Unit = {}
+            stubMapper: ExceptionPresentationMapper.() -> Unit = {}
         ) = arrayOf(connectionDetails, viewState, stubMapper)
 
         private fun connectedTestCase(
@@ -109,20 +109,20 @@ class ConnectionStateToPresentationMapperTest(
     @get:Rule
     val mockitoRule: MethodRule = MockitoJUnit.rule()
 
-    private lateinit var classUnderTest: ConnectionStateToPresentationMapper
+    private lateinit var classUnderTest: ConnectionDetailsPresentationMapper
 
     @Mock
-    lateinit var exceptionToPresentationMapper: ExceptionToPresentationMapper
+    lateinit var exceptionPresentationMapper: ExceptionPresentationMapper
 
     @Before
     fun setUp() {
-        classUnderTest = ConnectionStateToPresentationMapper(exceptionToPresentationMapper)
+        classUnderTest = ConnectionDetailsPresentationMapper(exceptionPresentationMapper)
     }
 
     @Test
     fun `When toPresentation`() {
         // Given
-        exceptionToPresentationMapper.stubMapper()
+        exceptionPresentationMapper.stubMapper()
 
         // When
         val actualValue = classUnderTest.toPresentation(givenConnectionDetails)

--- a/home/presentation/src/test/java/com/mitteloupe/whoami/home/presentation/mapper/ExceptionPresentationMapperTest.kt
+++ b/home/presentation/src/test/java/com/mitteloupe/whoami/home/presentation/mapper/ExceptionPresentationMapperTest.kt
@@ -14,7 +14,7 @@ import org.junit.runners.Parameterized
 import org.junit.runners.Parameterized.Parameters
 
 @RunWith(Parameterized::class)
-class ExceptionToPresentationMapperTest(
+class ExceptionPresentationMapperTest(
     private val givenDomainException: DomainException,
     private val expectedPresentationError: ErrorPresentationModel
 ) {
@@ -40,11 +40,11 @@ class ExceptionToPresentationMapperTest(
         )
     }
 
-    private lateinit var classUnderTest: ExceptionToPresentationMapper
+    private lateinit var classUnderTest: ExceptionPresentationMapper
 
     @Before
     fun setUp() {
-        classUnderTest = ExceptionToPresentationMapper()
+        classUnderTest = ExceptionPresentationMapper()
     }
 
     @Test

--- a/home/presentation/src/test/java/com/mitteloupe/whoami/home/presentation/viewmodel/HomeViewModelTest.kt
+++ b/home/presentation/src/test/java/com/mitteloupe/whoami/home/presentation/viewmodel/HomeViewModelTest.kt
@@ -6,9 +6,9 @@ import com.mitteloupe.whoami.home.domain.model.ConnectionDetailsDomainModel
 import com.mitteloupe.whoami.home.domain.model.ConnectionDetailsDomainModel.Disconnected
 import com.mitteloupe.whoami.home.domain.usecase.GetConnectionDetailsUseCase
 import com.mitteloupe.whoami.home.domain.usecase.SaveConnectionDetailsUseCase
+import com.mitteloupe.whoami.home.presentation.mapper.ConnectionDetailsPresentationMapper
 import com.mitteloupe.whoami.home.presentation.mapper.ConnectionDetailsToDomainMapper
-import com.mitteloupe.whoami.home.presentation.mapper.ConnectionStateToPresentationMapper
-import com.mitteloupe.whoami.home.presentation.mapper.ExceptionToPresentationMapper
+import com.mitteloupe.whoami.home.presentation.mapper.ExceptionPresentationMapper
 import com.mitteloupe.whoami.home.presentation.model.HomePresentationNotification
 import com.mitteloupe.whoami.home.presentation.model.HomeViewState
 import com.mitteloupe.whoami.home.presentation.model.HomeViewState.Loading
@@ -40,7 +40,7 @@ class HomeViewModelTest :
     private lateinit var getConnectionDetailsUseCase: GetConnectionDetailsUseCase
 
     @Mock
-    private lateinit var connectionStateToPresentationMapper: ConnectionStateToPresentationMapper
+    private lateinit var connectionDetailsPresentationMapper: ConnectionDetailsPresentationMapper
 
     @Mock
     private lateinit var saveConnectionDetailsUseCase: SaveConnectionDetailsUseCase
@@ -49,16 +49,16 @@ class HomeViewModelTest :
     private lateinit var connectionDetailsToDomainMapper: ConnectionDetailsToDomainMapper
 
     @Mock
-    private lateinit var exceptionToPresentationMapper: ExceptionToPresentationMapper
+    private lateinit var exceptionPresentationMapper: ExceptionPresentationMapper
 
     @Before
     fun setUp() {
         classUnderTest = HomeViewModel(
             getConnectionDetailsUseCase,
-            connectionStateToPresentationMapper,
+            connectionDetailsPresentationMapper,
             saveConnectionDetailsUseCase,
             connectionDetailsToDomainMapper,
-            exceptionToPresentationMapper,
+            exceptionPresentationMapper,
             useCaseExecutor
         )
     }
@@ -72,7 +72,7 @@ class HomeViewModelTest :
             givenConnectionState
         )
         val expectedViewState = HomeViewState.Disconnected
-        given { connectionStateToPresentationMapper.toPresentation(givenConnectionState) }
+        given { connectionDetailsPresentationMapper.toPresentation(givenConnectionState) }
             .willReturn(expectedViewState)
 
         // When


### PR DESCRIPTION
`ConnectionStateToPresentationMapper` to `ConnectionDetailsPresentationMapper` for consistency.
Omitted "To" from mapper names for brevity.
