### PR TITLE
Renamed ServerResponse to MockResponse for consistency with request.

### DIFF
--- a/app/src/androidTest/java/com/mitteloupe/whoami/server/AppResponseStore.kt
+++ b/app/src/androidTest/java/com/mitteloupe/whoami/server/AppResponseStore.kt
@@ -4,7 +4,7 @@ import com.mitteloupe.whoami.constant.IP_ADDRESS
 import com.mitteloupe.whoami.test.server.MockRequest
 import com.mitteloupe.whoami.test.server.MockRequestResponse
 import com.mitteloupe.whoami.test.server.ResponseStore
-import com.mitteloupe.whoami.test.server.response.SimpleResponse
+import com.mitteloupe.whoami.test.server.response.SimpleResponseFactory
 
 const val IPIFY_ENDPOINT = "/ipify/"
 const val IPINFO_ENDPOINT = "/ipinfo/"
@@ -16,11 +16,11 @@ class AppResponseStore : ResponseStore() {
     override val internalResponses = listOf(
         REQUEST_RESPONSE_GET_IP to MockRequestResponse(
             request = MockRequest(IPIFY_ENDPOINT),
-            response = SimpleResponse(200, "api/get_ip.json")
+            response = SimpleResponseFactory(200, "api/get_ip.json")
         ),
         REQUEST_RESPONSE_GET_IP_DETAILS to MockRequestResponse(
             request = MockRequest("${IPINFO_ENDPOINT}$IP_ADDRESS/geo"),
-            response = SimpleResponse(200, "api/get_ip_details.json")
+            response = SimpleResponseFactory(200, "api/get_ip_details.json")
         )
     )
 }

--- a/app/src/androidTest/java/com/mitteloupe/whoami/server/AppResponseStore.kt
+++ b/app/src/androidTest/java/com/mitteloupe/whoami/server/AppResponseStore.kt
@@ -2,7 +2,7 @@ package com.mitteloupe.whoami.server
 
 import com.mitteloupe.whoami.constant.IP_ADDRESS
 import com.mitteloupe.whoami.test.server.MockRequest
-import com.mitteloupe.whoami.test.server.MockRequestResponse
+import com.mitteloupe.whoami.test.server.MockRequestResponseFactory
 import com.mitteloupe.whoami.test.server.ResponseStore
 import com.mitteloupe.whoami.test.server.response.SimpleResponseFactory
 
@@ -13,14 +13,14 @@ const val REQUEST_RESPONSE_GET_IP = "Get IP"
 const val REQUEST_RESPONSE_GET_IP_DETAILS = "Get IP Details"
 
 class AppResponseStore : ResponseStore() {
-    override val internalResponses = listOf(
-        REQUEST_RESPONSE_GET_IP to MockRequestResponse(
+    override val internalResponseFactories = listOf(
+        REQUEST_RESPONSE_GET_IP to MockRequestResponseFactory(
             request = MockRequest(IPIFY_ENDPOINT),
-            response = SimpleResponseFactory(200, "api/get_ip.json")
+            responseFactory = SimpleResponseFactory(200, "api/get_ip.json")
         ),
-        REQUEST_RESPONSE_GET_IP_DETAILS to MockRequestResponse(
+        REQUEST_RESPONSE_GET_IP_DETAILS to MockRequestResponseFactory(
             request = MockRequest("${IPINFO_ENDPOINT}$IP_ADDRESS/geo"),
-            response = SimpleResponseFactory(200, "api/get_ip_details.json")
+            responseFactory = SimpleResponseFactory(200, "api/get_ip_details.json")
         )
     )
 }

--- a/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/server/MockDispatcher.kt
+++ b/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/server/MockDispatcher.kt
@@ -1,6 +1,6 @@
 package com.mitteloupe.whoami.test.server
 
-import com.mitteloupe.whoami.test.server.response.MockResponseContents
+import com.mitteloupe.whoami.test.server.response.MockResponseFactory
 import okhttp3.Headers
 import okhttp3.Response
 import okhttp3.WebSocket
@@ -15,13 +15,13 @@ class MockDispatcher :
     override val usedEndpoints: Set<String>
         field = mutableSetOf<String>()
 
-    private val responses = mutableMapOf<String, MockResponseContents>()
+    private val responses = mutableMapOf<String, MockResponseFactory>()
 
     var webSocket: WebSocket? = null
 
     override var onWebSocketMessage: (String) -> Unit = {}
 
-    override fun bindResponse(request: MockRequest, response: MockResponseContents) {
+    override fun bindResponse(request: MockRequest, response: MockResponseFactory) {
         responses[request.url] = response
     }
 

--- a/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/server/MockDispatcher.kt
+++ b/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/server/MockDispatcher.kt
@@ -33,7 +33,7 @@ class MockDispatcher :
     override fun dispatch(request: RecordedRequest): MockResponse {
         val endPoint = request.path!!.substringBefore("?")
         usedEndpoints.add(endPoint)
-        val response = responses[endPoint]?.mockResponse(this) ?: ServerResponse(code = 404)
+        val response = responses[endPoint]?.mockResponse() ?: MockResponse(code = 404)
         return if (response.upgradeToWebSocket) {
             MockResponse().withWebSocketUpgrade(
                 object : WebSocketListener() {

--- a/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/server/MockRequestResponse.kt
+++ b/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/server/MockRequestResponse.kt
@@ -1,5 +1,5 @@
 package com.mitteloupe.whoami.test.server
 
-import com.mitteloupe.whoami.test.server.response.MockResponseContents
+import com.mitteloupe.whoami.test.server.response.MockResponseFactory
 
-data class MockRequestResponse(val request: MockRequest, val response: MockResponseContents)
+data class MockRequestResponse(val request: MockRequest, val response: MockResponseFactory)

--- a/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/server/MockRequestResponse.kt
+++ b/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/server/MockRequestResponse.kt
@@ -1,5 +1,0 @@
-package com.mitteloupe.whoami.test.server
-
-import com.mitteloupe.whoami.test.server.response.MockResponseFactory
-
-data class MockRequestResponse(val request: MockRequest, val response: MockResponseFactory)

--- a/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/server/MockRequestResponseFactory.kt
+++ b/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/server/MockRequestResponseFactory.kt
@@ -1,0 +1,8 @@
+package com.mitteloupe.whoami.test.server
+
+import com.mitteloupe.whoami.test.server.response.MockResponseFactory
+
+data class MockRequestResponseFactory(
+    val request: MockRequest,
+    val responseFactory: MockResponseFactory
+)

--- a/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/server/MockResponse.kt
+++ b/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/server/MockResponse.kt
@@ -1,6 +1,6 @@
 package com.mitteloupe.whoami.test.server
 
-data class ServerResponse(
+data class MockResponse(
     val upgradeToWebSocket: Boolean = false,
     val code: Int = 200,
     val headers: List<Pair<String, String>> = emptyList(),

--- a/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/server/ResponseBinder.kt
+++ b/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/server/ResponseBinder.kt
@@ -1,13 +1,13 @@
 package com.mitteloupe.whoami.test.server
 
-import com.mitteloupe.whoami.test.server.response.MockResponseContents
+import com.mitteloupe.whoami.test.server.response.MockResponseFactory
 
 interface ResponseBinder {
     var onWebSocketMessage: (String) -> Unit
 
     val usedEndpoints: Set<String>
 
-    fun bindResponse(request: MockRequest, response: MockResponseContents)
+    fun bindResponse(request: MockRequest, response: MockResponseFactory)
 
     fun reset()
 }

--- a/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/server/ResponseStore.kt
+++ b/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/server/ResponseStore.kt
@@ -1,14 +1,14 @@
 package com.mitteloupe.whoami.test.server
 
-private typealias MockRequestResponsePairList = List<Pair<String, MockRequestResponse>>
-private typealias MockRequestResponseMap = Map<String, MockRequestResponse>
+private typealias MockRequestResponsePairList = List<Pair<String, MockRequestResponseFactory>>
+private typealias MockRequestResponseMap = Map<String, MockRequestResponseFactory>
 
 abstract class ResponseStore {
-    val responses by lazy {
-        internalResponses.toValidatedMap()
+    val responseFactories by lazy {
+        internalResponseFactories.toValidatedMap()
     }
 
-    protected abstract val internalResponses: List<Pair<String, MockRequestResponse>>
+    protected abstract val internalResponseFactories: List<Pair<String, MockRequestResponseFactory>>
 
     private fun MockRequestResponsePairList.toValidatedMap(): MockRequestResponseMap {
         val responses = toMap()

--- a/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/server/response/ErrorResponse.kt
+++ b/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/server/response/ErrorResponse.kt
@@ -1,12 +1,9 @@
 package com.mitteloupe.whoami.test.server.response
 
-import com.mitteloupe.whoami.test.server.ResponseBinder
-import com.mitteloupe.whoami.test.server.ServerResponse
+import com.mitteloupe.whoami.test.server.MockResponse
 
 sealed class ErrorResponse {
     object NotFound : MockResponseContents {
-        override fun mockResponse(responseBinder: ResponseBinder) = ServerResponse(
-            code = 404
-        )
+        override fun mockResponse() = MockResponse(code = 404)
     }
 }

--- a/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/server/response/ErrorResponseFactory.kt
+++ b/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/server/response/ErrorResponseFactory.kt
@@ -2,8 +2,8 @@ package com.mitteloupe.whoami.test.server.response
 
 import com.mitteloupe.whoami.test.server.MockResponse
 
-sealed class ErrorResponse {
-    object NotFound : MockResponseContents {
+sealed class ErrorResponseFactory {
+    object NotFound : MockResponseFactory {
         override fun mockResponse() = MockResponse(code = 404)
     }
 }

--- a/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/server/response/MockResponseContents.kt
+++ b/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/server/response/MockResponseContents.kt
@@ -1,8 +1,7 @@
 package com.mitteloupe.whoami.test.server.response
 
-import com.mitteloupe.whoami.test.server.ResponseBinder
-import com.mitteloupe.whoami.test.server.ServerResponse
+import com.mitteloupe.whoami.test.server.MockResponse
 
 interface MockResponseContents {
-    fun mockResponse(responseBinder: ResponseBinder): ServerResponse
+    fun mockResponse(): MockResponse
 }

--- a/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/server/response/MockResponseFactory.kt
+++ b/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/server/response/MockResponseFactory.kt
@@ -2,6 +2,6 @@ package com.mitteloupe.whoami.test.server.response
 
 import com.mitteloupe.whoami.test.server.MockResponse
 
-interface MockResponseContents {
+interface MockResponseFactory {
     fun mockResponse(): MockResponse
 }

--- a/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/server/response/SequenceResponse.kt
+++ b/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/server/response/SequenceResponse.kt
@@ -1,16 +1,15 @@
 package com.mitteloupe.whoami.test.server.response
 
-import com.mitteloupe.whoami.test.server.ResponseBinder
-import com.mitteloupe.whoami.test.server.ServerResponse
+import com.mitteloupe.whoami.test.server.MockResponse
 
 class SequenceResponse(private vararg val responses: MockResponseContents) : MockResponseContents {
     private var responseIndex = 0
-    override fun mockResponse(responseBinder: ResponseBinder): ServerResponse {
+    override fun mockResponse(): MockResponse {
         val mockResponse = responses[responseIndex]
         responseIndex++
         if (responseIndex == responses.size) {
             responseIndex = 0
         }
-        return mockResponse.mockResponse(responseBinder)
+        return mockResponse.mockResponse()
     }
 }

--- a/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/server/response/SequenceResponseFactory.kt
+++ b/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/server/response/SequenceResponseFactory.kt
@@ -2,7 +2,8 @@ package com.mitteloupe.whoami.test.server.response
 
 import com.mitteloupe.whoami.test.server.MockResponse
 
-class SequenceResponse(private vararg val responses: MockResponseContents) : MockResponseContents {
+class SequenceResponseFactory(private vararg val responses: MockResponseFactory) :
+    MockResponseFactory {
     private var responseIndex = 0
     override fun mockResponse(): MockResponse {
         val mockResponse = responses[responseIndex]

--- a/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/server/response/SimpleResponse.kt
+++ b/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/server/response/SimpleResponse.kt
@@ -1,8 +1,7 @@
 package com.mitteloupe.whoami.test.server.response
 
 import com.mitteloupe.whoami.test.asset.assetReader
-import com.mitteloupe.whoami.test.server.ResponseBinder
-import com.mitteloupe.whoami.test.server.ServerResponse
+import com.mitteloupe.whoami.test.server.MockResponse
 
 data class SimpleResponse(
     private val code: Int = 200,
@@ -17,6 +16,5 @@ data class SimpleResponse(
         }
     }
 
-    override fun mockResponse(responseBinder: ResponseBinder) =
-        ServerResponse(code = code, headers = headers, body = body)
+    override fun mockResponse() = MockResponse(code = code, headers = headers, body = body)
 }

--- a/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/server/response/SimpleResponseFactory.kt
+++ b/architecture/instrumentation-test/src/main/java/com/mitteloupe/whoami/test/server/response/SimpleResponseFactory.kt
@@ -3,11 +3,11 @@ package com.mitteloupe.whoami.test.server.response
 import com.mitteloupe.whoami.test.asset.assetReader
 import com.mitteloupe.whoami.test.server.MockResponse
 
-data class SimpleResponse(
+data class SimpleResponseFactory(
     private val code: Int = 200,
     private val bodyFileName: String = "",
     private val headers: List<Pair<String, String>> = emptyList()
-) : MockResponseContents {
+) : MockResponseFactory {
     private val body by lazy {
         if (bodyFileName.isEmpty()) {
             ""


### PR DESCRIPTION
Simplified responses by removing unused argument.
Renamed responses to response factories for better clarity of their role.