### PR TITLE
Enable the kernel virtual machine.

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -89,6 +89,12 @@ jobs:
       - name: Save logcat output
         run: adb logcat > logcat.txt &
 
+      - name: Enable KVM group permissions
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - name: Run connected tests
         uses: ReactiveCircus/android-emulator-runner@v2
         with:


### PR DESCRIPTION
Enabled the kernel virtual machine (KVM), as per https://github.com/ReactiveCircus/android-emulator-runner:

> GitHub's [larger Linux runners support running hardware accelerated emulators](https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/). It is now recommended to use the Ubuntu (ubuntu-latest) runners which are 2-3 times faster than the macOS ones which are also a lot more expensive. Remember to enable KVM in your workflow before running this action